### PR TITLE
Initialize static variables atomically

### DIFF
--- a/JMImageCache.m
+++ b/JMImageCache.m
@@ -8,12 +8,13 @@
 
 #import "JMImageCache.h"
 
-static NSString *_JMImageCacheDirectory;
-
 static inline NSString *JMImageCacheDirectory() {
-	if(!_JMImageCacheDirectory) {
+	static NSString *_JMImageCacheDirectory;
+	static dispatch_once_t onceToken;
+    
+	dispatch_once(&onceToken, ^{
 		_JMImageCacheDirectory = [[NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches/JMCache"] copy];
-	}
+	});
 
 	return _JMImageCacheDirectory;
 }
@@ -24,8 +25,6 @@ static inline NSString *cachePathForKey(NSString *key) {
     NSString *fileName = [NSString stringWithFormat:@"JMImageCache-%u", [key hash]];
 	return [JMImageCacheDirectory() stringByAppendingPathComponent:fileName];
 }
-
-JMImageCache *_sharedCache = nil;
 
 @interface JMImageCache ()
 
@@ -40,9 +39,12 @@ JMImageCache *_sharedCache = nil;
 @synthesize diskOperationQueue = _diskOperationQueue;
 
 + (JMImageCache *) sharedCache {
-	if(!_sharedCache) {
+	static JMImageCache *_sharedCache = nil;
+	static dispatch_once_t onceToken;
+
+	dispatch_once(&onceToken, ^{
 		_sharedCache = [[JMImageCache alloc] init];
-	}
+	});
 
 	return _sharedCache;
 }


### PR DESCRIPTION
Hello Jake,

Thanks for the useful library. I've noticed that some global variables are not initialized atomically. I haven't run into any problems but I think it would be safer to initialize them using `dispatch_once`, to prevent potential race conditions between the very first two calls to `setImageURL...`. If you place breakpoints in both places and remove the call to `removeAllImages` from the demo program, you can see that they are indeed being called from different threads.
