### PR TITLE
Format key hash to unsigned long in string, remove format string warning

### DIFF
--- a/JMImageCache.m
+++ b/JMImageCache.m
@@ -22,7 +22,7 @@ inline static NSString *keyForURL(NSURL *url) {
 	return [url absoluteString];
 }
 static inline NSString *cachePathForKey(NSString *key) {
-    NSString *fileName = [NSString stringWithFormat:@"JMImageCache-%u", [key hash]];
+    NSString *fileName = [NSString stringWithFormat:@"JMImageCache-%lu", (unsigned long)[key hash]];
 	return [JMImageCacheDirectory() stringByAppendingPathComponent:fileName];
 }
 


### PR DESCRIPTION
Removes that pesky Xcode fix-it warning.
